### PR TITLE
Create season standings pane

### DIFF
--- a/cfl-predictor/src/App.js
+++ b/cfl-predictor/src/App.js
@@ -1,5 +1,8 @@
 import './App.css';
+
 import {useState} from 'react';
+
+import {ContentSeasonStandings} from './PageSeasonStandings';
 
 
 function App() {
@@ -69,16 +72,6 @@ function ContentPage(props) {
   }
   else if(props.pageName === "test") return <ContentTestPage />
   else return <p>Error - invalid page name</p>
-}
-
-function ContentSeasonStandings() {
-  return(
-    <div>
-      <p>
-      This is the content pane for Season Standings.
-      </p>
-    </div>
-  );
 }
 
 function ContentTestPage() {

--- a/cfl-predictor/src/PageSeasonStandings.js
+++ b/cfl-predictor/src/PageSeasonStandings.js
@@ -1,9 +1,49 @@
-export function ContentSeasonStandings() {
+import {useState} from 'react';
+
+function ContentSeasonStandings() {
+  const [displayPage, setDisplayPage] = useState("regular-season");
   return(
       <div>
-          <p>
-          This is the content pane for Season Standings.
-          </p>
+          <SeasonStandingsNavBar setDisplayPage = {setDisplayPage} />
+          <SeasonTable displayPage={displayPage} />
       </div>
   );
 }
+
+function SeasonStandingsNavBar(props) {
+  return(
+    <div className="ButtonStrip">
+      <SeasonStandingsNavButton 
+        text='Regular Season Rankings'
+        setDisplayPage = {props.setDisplayPage}
+        pageName='pageA'
+      />
+      <SeasonStandingsNavButton
+        text='Crossover'
+        setDisplayPage = {props.setDisplayPage}
+        pageName='pageB'
+      />
+    </div> 
+  );  
+}
+
+function SeasonStandingsNavButton(props) {
+  function handleClick(){
+    props.setDisplayPage(props.pageName);
+  }
+  return(
+    <button onClick={handleClick}>
+      {props.text}
+    </button>
+  );
+}
+
+function SeasonTable(props) {
+  if(props.displayPage === 'pageA') return(<p>Page A</p>);
+  else if (props.displayPage === 'pageB') return(<p>Page B</p>);
+  else return(<p>Error</p>);
+}
+
+export {
+  ContentSeasonStandings
+};

--- a/cfl-predictor/src/PageSeasonStandings.js
+++ b/cfl-predictor/src/PageSeasonStandings.js
@@ -1,0 +1,9 @@
+export function ContentSeasonStandings() {
+  return(
+      <div>
+          <p>
+          This is the content pane for Season Standings.
+          </p>
+      </div>
+  );
+}

--- a/cfl-predictor/src/PageSeasonStandings.js
+++ b/cfl-predictor/src/PageSeasonStandings.js
@@ -10,6 +10,22 @@ function ContentSeasonStandings() {
   );
 }
 
+function CrossoverRankingTable() {
+  return(
+    <div>
+      <h2>Season Rankings - Crossover</h2>
+    </div>
+  );
+}
+
+function RegularRankingTable() {
+  return(
+    <div>
+      <h2>Season Rankings - Regular</h2>
+    </div>
+  );
+}
+
 function SeasonStandingsNavBar(props) {
   return(
     <div className="ButtonStrip">
@@ -39,9 +55,8 @@ function SeasonStandingsNavButton(props) {
 }
 
 function SeasonTable(props) {
-  if(props.displayPage === 'pageA') return(<p>Page A</p>);
-  else if (props.displayPage === 'pageB') return(<p>Page B</p>);
-  else return(<p>Error</p>);
+  if(props.displayPage === 'pageA') return(<RegularRankingTable />);
+  else if (props.displayPage === 'pageB') return(<CrossoverRankingTable />);
 }
 
 export {


### PR DESCRIPTION
The content page for Season Standings has had its components moved to a separate file. Users can toggle this page between two views.