### PR TITLE
Debug DivisionTable props passing

### DIFF
--- a/cfl-predictor/src/PageSeasonStandings.js
+++ b/cfl-predictor/src/PageSeasonStandings.js
@@ -60,7 +60,7 @@ function DivisionTable(props){
 function DivisionTableBody(props) {
   const rows = props.rows;
   for(let i=0; i<rows.length; i++){
-    const row=rows[i];
+    const row=rows[i].props;
     return(
       <DivisionTableRow 
         rank={row.rank}

--- a/cfl-predictor/src/PageSeasonStandings.js
+++ b/cfl-predictor/src/PageSeasonStandings.js
@@ -60,8 +60,8 @@ function DivisionTable(props){
 
 function DivisionTableBody(props) {
   const rows = props.rows;
-  for(let i=0; i<length; i++){
-    row=rows[i];
+  for(let i=0; i<rows.length; i++){
+    const row=rows[i];
     return(
       <DivisionTableRow 
         rank={row.rank}
@@ -76,10 +76,12 @@ function DivisionTableBody(props) {
 }
 
 function DivisionTableRow(props) {
+  console.log(props.rank);
+  console.log(props.teamName);
   return(
     <tr>
       <td>{props.rank}</td>
-      <td></td>
+      <td>img</td>
       <td>{props.teamName}</td>
       <td>{props.games}</td>
       <td>{props.wins}</td>

--- a/cfl-predictor/src/PageSeasonStandings.js
+++ b/cfl-predictor/src/PageSeasonStandings.js
@@ -42,7 +42,6 @@ function DivisionTable(props){
         <thead>
           <tr>
             <th>Rank</th>
-            <th></th> {/* will contain team logo */}
             <th>Team</th>
             <th>Games</th>
             <th>Wins</th>
@@ -76,12 +75,9 @@ function DivisionTableBody(props) {
 }
 
 function DivisionTableRow(props) {
-  console.log(props.rank);
-  console.log(props.teamName);
   return(
     <tr>
       <td>{props.rank}</td>
-      <td>img</td>
       <td>{props.teamName}</td>
       <td>{props.games}</td>
       <td>{props.wins}</td>


### PR DESCRIPTION
When DivisionTable passed an array of props to child classes, runtime errors were occurring due to undefined values. Since DivisionTable was passing an array of components, reading props.array was unsuccessful. I changed it to props.array.props and app can now pass the required values.